### PR TITLE
Servo implementation

### DIFF
--- a/rpi-servo/config.go
+++ b/rpi-servo/config.go
@@ -12,11 +12,11 @@ type ServoConfig struct {
 	BoardName string `json:"board"`
 	Pin       string `json:"pin"`
 
-	Min         int      `json:"min,omitempty"` // specifies a user inputted minimum position limitation
-	Max         int      `json:"max,omitempty"` // specifies a user inputted maximum position limitation
-	StartPos    *float64 `json:"starting_position_degs,omitempty"`
-	HoldPos     *bool    `json:"hold_position,omitempty"`    // defaults True. False holds for 500 ms then disables servo
-	MaxRotation int      `json:"max_rotation_deg,omitempty"` // specifies a hardware position limitation. Defaults to 180
+	Min         int      `json:"min,omitempty"`                    // specifies a user inputted minimum position limitation
+	Max         int      `json:"max,omitempty"`                    // specifies a user inputted maximum position limitation
+	StartPos    *float64 `json:"starting_position_degs,omitempty"` // specifies a starting position. Defaults to 90
+	HoldPos     *bool    `json:"hold_position,omitempty"`          // defaults True. False holds for 500 ms then disables servo
+	MaxRotation int      `json:"max_rotation_deg,omitempty"`       // specifies a hardware position limitation. Defaults to 180
 }
 
 // Validate ensures all parts of the config are valid.

--- a/rpi-servo/rpiservo.go
+++ b/rpi-servo/rpiservo.go
@@ -62,6 +62,8 @@ func newPiServo(
 	conf resource.Config,
 	logger logging.Logger,
 ) (servo.Servo, error) {
+	// TODO: Organize code with helepr functions
+
 	newConf, err := resource.NativeConfig[*ServoConfig](conf)
 	if err != nil {
 		return nil, err
@@ -82,24 +84,12 @@ func newPiServo(
 		pin:    C.uint(bcom),
 		opMgr:  operation.NewSingleOperationManager(),
 	}
-	if newConf.Min > 0 {
-		theServo.min = uint32(newConf.Min)
-	}
-	if newConf.Max > 0 {
-		theServo.max = uint32(newConf.Max)
-	}
-	theServo.maxRotation = uint32(newConf.MaxRotation)
-	if theServo.maxRotation == 0 {
-		theServo.maxRotation = uint32(servoDefaultMaxRotation)
-	}
-	if theServo.maxRotation < theServo.min {
-		return nil, errors.New("maxRotation is less than minimum")
-	}
-	if theServo.maxRotation < theServo.max {
-		return nil, errors.New("maxRotation is less than maximum")
-	}
 
-	theServo.pinname = newConf.Pin
+	// Validate the and set servo configuration
+	err = theServo.validateAndSetConfiguration(newConf)
+	if err != nil {
+		return nil, err
+	}
 
 	// Start separate connection from board to pigpio daemon
 	// Needs to be called before using other pigpio functions

--- a/rpi-servo/utils.go
+++ b/rpi-servo/utils.go
@@ -1,0 +1,31 @@
+package rpiservo
+
+/*
+	Helper functions for the piservo.
+*/
+
+import "github.com/pkg/errors"
+
+// Validate and set piPigpioServo fields based on the configuration.
+func (s *piPigpioServo) validateAndSetConfiguration(conf *ServoConfig) error {
+	if conf.Min > 0 {
+		s.min = uint32(conf.Min)
+	}
+	if conf.Max > 0 {
+		s.max = uint32(conf.Max)
+	}
+	s.maxRotation = uint32(conf.MaxRotation)
+	if s.maxRotation == 0 {
+		s.maxRotation = uint32(servoDefaultMaxRotation)
+	}
+	if s.maxRotation < s.min {
+		return errors.New("maxRotation is less than minimum")
+	}
+	if s.maxRotation < s.max {
+		return errors.New("maxRotation is less than maximum")
+	}
+
+	s.pinname = conf.Pin
+
+	return nil
+}


### PR DESCRIPTION
# Changes
Port rdk servo implementation into RDK + refactor
- Initialize `pigpio_start()` on boot
- Remove trivially closeable and create close function to call `pigpio_stop`
- Move constructor to separate function with same semantic definition as `rpi.go`