### PR TITLE
Change piID to a C.int type

### DIFF
--- a/rpi/gpio.go
+++ b/rpi/gpio.go
@@ -67,7 +67,7 @@ func (pi *piPigpio) GetGPIOBcom(bcom int) (bool, error) {
 		if pi.gpioConfigSet == nil {
 			pi.gpioConfigSet = map[int]bool{}
 		}
-		res := C.set_mode(C.int(pi.piID), C.uint(bcom), C.PI_INPUT)
+		res := C.set_mode(pi.piID, C.uint(bcom), C.PI_INPUT)
 		if res != 0 {
 			return false, rpiutils.ConvertErrorCodeToMessage(int(res), "failed to set mode")
 		}
@@ -75,7 +75,7 @@ func (pi *piPigpio) GetGPIOBcom(bcom int) (bool, error) {
 	}
 
 	// gpioRead retrns an int 1 or 0, we convert to a bool
-	return C.gpio_read(C.int(pi.piID), C.uint(bcom)) != 0, nil
+	return C.gpio_read(pi.piID, C.uint(bcom)) != 0, nil
 }
 
 // SetGPIOBcom sets the given broadcom pin to high or low.
@@ -86,7 +86,7 @@ func (pi *piPigpio) SetGPIOBcom(bcom int, high bool) error {
 		if pi.gpioConfigSet == nil {
 			pi.gpioConfigSet = map[int]bool{}
 		}
-		res := C.set_mode(C.int(pi.piID), C.uint(bcom), C.PI_OUTPUT)
+		res := C.set_mode(pi.piID, C.uint(bcom), C.PI_OUTPUT)
 		if res != 0 {
 			return rpiutils.ConvertErrorCodeToMessage(int(res), "failed to set mode")
 		}
@@ -97,12 +97,12 @@ func (pi *piPigpio) SetGPIOBcom(bcom int, high bool) error {
 	if high {
 		v = 1
 	}
-	C.gpio_write(C.int(pi.piID), C.uint(bcom), C.uint(v))
+	C.gpio_write(pi.piID, C.uint(bcom), C.uint(v))
 	return nil
 }
 
 func (pi *piPigpio) pwmBcom(bcom int) (float64, error) {
-	res := C.get_PWM_dutycycle(C.int(pi.piID), C.uint(bcom))
+	res := C.get_PWM_dutycycle(pi.piID, C.uint(bcom))
 	return float64(res) / 255, nil
 }
 
@@ -111,7 +111,7 @@ func (pi *piPigpio) SetPWMBcom(bcom int, dutyCyclePct float64) error {
 	pi.mu.Lock()
 	defer pi.mu.Unlock()
 	dutyCycle := rdkutils.ScaleByPct(255, dutyCyclePct)
-	pi.duty = int(C.set_PWM_dutycycle(C.int(pi.piID), C.uint(bcom), C.uint(dutyCycle)))
+	pi.duty = int(C.set_PWM_dutycycle(pi.piID, C.uint(bcom), C.uint(dutyCycle)))
 	if pi.duty != 0 {
 		return errors.Errorf("pwm set fail %d", pi.duty)
 	}
@@ -119,7 +119,7 @@ func (pi *piPigpio) SetPWMBcom(bcom int, dutyCyclePct float64) error {
 }
 
 func (pi *piPigpio) pwmFreqBcom(bcom int) (uint, error) {
-	res := C.get_PWM_frequency(C.int(pi.piID), C.uint(bcom))
+	res := C.get_PWM_frequency(pi.piID, C.uint(bcom))
 	return uint(res), nil
 }
 
@@ -130,7 +130,7 @@ func (pi *piPigpio) SetPWMFreqBcom(bcom int, freqHz uint) error {
 	if freqHz == 0 {
 		freqHz = 800 // Original default from libpigpio
 	}
-	newRes := C.set_PWM_frequency(C.int(pi.piID), C.uint(bcom), C.uint(freqHz))
+	newRes := C.set_PWM_frequency(pi.piID, C.uint(bcom), C.uint(freqHz))
 
 	if newRes == C.PI_BAD_USER_GPIO {
 		return rpiutils.ConvertErrorCodeToMessage(int(newRes), "pwm set freq failed")

--- a/rpi/i2c.go
+++ b/rpi/i2c.go
@@ -32,7 +32,7 @@ func (s *piPigpioI2CHandle) Write(ctx context.Context, tx []byte) error {
 	txPtr := C.CBytes(tx)
 	defer C.free(txPtr)
 
-	ret := int(C.i2c_write_device(C.int(s.bus.pi.piID), s.handle, (*C.char)(txPtr), (C.uint)(len(tx))))
+	ret := int(C.i2c_write_device(s.bus.pi.piID, s.handle, (*C.char)(txPtr), (C.uint)(len(tx))))
 
 	if ret != 0 {
 		return picommon.ConvertErrorCodeToMessage(ret, "error with i2c write")
@@ -47,7 +47,7 @@ func (s *piPigpioI2CHandle) Read(ctx context.Context, count int) ([]byte, error)
 	rxPtr := C.CBytes(rx)
 	defer C.free(rxPtr)
 
-	ret := int(C.i2c_read_device(C.int(s.bus.pi.piID), s.handle, (*C.char)(rxPtr), (C.uint)(count)))
+	ret := int(C.i2c_read_device(s.bus.pi.piID, s.handle, (*C.char)(rxPtr), (C.uint)(count)))
 
 	if ret <= 0 {
 		return nil, picommon.ConvertErrorCodeToMessage(ret, "error with i2c read")
@@ -57,7 +57,7 @@ func (s *piPigpioI2CHandle) Read(ctx context.Context, count int) ([]byte, error)
 }
 
 func (s *piPigpioI2CHandle) ReadByteData(ctx context.Context, register byte) (byte, error) {
-	res := C.i2c_read_byte_data(C.int(s.bus.pi.piID), s.handle, C.uint(register))
+	res := C.i2c_read_byte_data(s.bus.pi.piID, s.handle, C.uint(register))
 	if res < 0 {
 		return 0, picommon.ConvertErrorCodeToMessage(int(res), "error in ReadByteData")
 	}
@@ -65,7 +65,7 @@ func (s *piPigpioI2CHandle) ReadByteData(ctx context.Context, register byte) (by
 }
 
 func (s *piPigpioI2CHandle) WriteByteData(ctx context.Context, register, data byte) error {
-	res := C.i2c_write_byte_data(C.int(s.bus.pi.piID), s.handle, C.uint(register), C.uint(data))
+	res := C.i2c_write_byte_data(s.bus.pi.piID, s.handle, C.uint(register), C.uint(data))
 	if res != 0 {
 		return picommon.ConvertErrorCodeToMessage(int(res), "error in WriteByteData")
 	}
@@ -79,7 +79,7 @@ func (s *piPigpioI2CHandle) ReadBlockData(ctx context.Context, register byte, nu
 
 	data := make([]byte, numBytes)
 	response := C.i2c_read_i2c_block_data(
-		C.int(s.bus.pi.piID), s.handle, C.uint(register), (*C.char)(&data[0]), C.uint(numBytes))
+		s.bus.pi.piID, s.handle, C.uint(register), (*C.char)(&data[0]), C.uint(numBytes))
 	if response < 0 {
 		return nil, picommon.ConvertErrorCodeToMessage(int(response), "error in ReadBlockData")
 	}
@@ -93,7 +93,7 @@ func (s *piPigpioI2CHandle) WriteBlockData(ctx context.Context, register byte, d
 	}
 
 	response := C.i2c_write_i2c_block_data(
-		C.int(s.bus.pi.piID), s.handle, C.uint(register), (*C.char)(&data[0]), C.uint(numBytes))
+		s.bus.pi.piID, s.handle, C.uint(register), (*C.char)(&data[0]), C.uint(numBytes))
 	if response != 0 {
 		return picommon.ConvertErrorCodeToMessage(int(response), "error in WriteBlockData")
 	}
@@ -118,6 +118,6 @@ func (s *piPigpioI2C) OpenHandle(addr byte) (buses.I2CHandle, error) {
 }
 
 func (s *piPigpioI2CHandle) Close() error {
-	C.i2c_close(C.int(s.bus.pi.piID), s.handle)
+	C.i2c_close(s.bus.pi.piID, s.handle)
 	return nil
 }

--- a/rpi/interrupts.go
+++ b/rpi/interrupts.go
@@ -93,7 +93,7 @@ func (pi *piPigpio) reconfigureInterrupts(ctx context.Context, cfg *Config) erro
 
 		if oldBcom, ok := findInterruptBcom(interrupt, oldInterruptsHW); ok {
 			delete(oldInterruptsHW, oldBcom)
-			if result := C.teardownInterrupt(C.int(pi.piID), C.int(oldBcom)); result != 0 {
+			if result := C.teardownInterrupt(pi.piID, C.int(oldBcom)); result != 0 {
 				return rpiutils.ConvertErrorCodeToMessage(int(result), "error")
 			}
 		} else {
@@ -103,7 +103,7 @@ func (pi *piPigpio) reconfigureInterrupts(ctx context.Context, cfg *Config) erro
 					"but couldn't find its old bcom!?", name, bcom)
 		}
 
-		if result := C.setupInterrupt(C.int(pi.piID), C.int(bcom)); result != 0 {
+		if result := C.setupInterrupt(pi.piID, C.int(bcom)); result != 0 {
 			return rpiutils.ConvertErrorCodeToMessage(int(result), "error")
 		}
 		return nil
@@ -137,7 +137,7 @@ func (pi *piPigpio) reconfigureInterrupts(ctx context.Context, cfg *Config) erro
 		}
 		newInterrupts[newConfig.Name] = di
 		newInterruptsHW[bcom] = di
-		if result := C.setupInterrupt(C.int(pi.piID), C.int(bcom)); result != 0 {
+		if result := C.setupInterrupt(pi.piID, C.int(bcom)); result != 0 {
 			return rpiutils.ConvertErrorCodeToMessage(int(result), "error")
 		}
 	}
@@ -163,7 +163,7 @@ func (pi *piPigpio) reconfigureInterrupts(ctx context.Context, cfg *Config) erro
 			newInterruptsHW[bcom] = interrupt
 		} else {
 			// This digital interrupt is no longer used.
-			if result := C.teardownInterrupt(C.int(pi.piID), C.int(bcom)); result != 0 {
+			if result := C.teardownInterrupt(pi.piID, C.int(bcom)); result != 0 {
 				return rpiutils.ConvertErrorCodeToMessage(int(result), "error")
 			}
 		}
@@ -208,7 +208,7 @@ func (pi *piPigpio) DigitalInterruptByName(name string) (board.DigitalInterrupt,
 			if err != nil {
 				return nil, err
 			}
-			if result := C.setupInterrupt(C.int(pi.piID), C.int(bcom)); result != 0 {
+			if result := C.setupInterrupt(pi.piID, C.int(bcom)); result != 0 {
 				err := rpiutils.ConvertErrorCodeToMessage(int(result), "error")
 				return nil, errors.Errorf("Unable to set up interrupt on pin %s: %s", name, err)
 			}

--- a/rpi/spi.go
+++ b/rpi/spi.go
@@ -94,13 +94,13 @@ func (s *piPigpioSPIHandle) Xfer(ctx context.Context, baud uint, chipSelect stri
 	txPtr := C.CBytes(tx)
 	defer C.free(txPtr)
 
-	handle := C.spi_open(C.int(s.bus.pi.piID), nativeCS, (C.uint)(baud), (C.uint)(spiFlags))
+	handle := C.spi_open(s.bus.pi.piID, nativeCS, (C.uint)(baud), (C.uint)(spiFlags))
 
 	if handle < 0 {
 		errMsg := fmt.Sprintf("error opening SPI Bus %s, flags were %X", s.bus.busSelect, spiFlags)
 		return nil, rpiutils.ConvertErrorCodeToMessage(int(handle), errMsg)
 	}
-	defer C.spi_close(C.int(s.bus.pi.piID), (C.uint)(handle))
+	defer C.spi_close(s.bus.pi.piID, (C.uint)(handle))
 
 	if gpioCS {
 		// We're going to directly control chip select (not using CE0/CE1/CE2 from SPI controller.)
@@ -116,7 +116,7 @@ func (s *piPigpioSPIHandle) Xfer(ctx context.Context, baud uint, chipSelect stri
 		}
 	}
 
-	ret := C.spi_xfer(C.int(s.bus.pi.piID), (C.uint)(handle), (*C.char)(txPtr), (*C.char)(rxPtr), (C.uint)(count))
+	ret := C.spi_xfer(s.bus.pi.piID, (C.uint)(handle), (*C.char)(txPtr), (*C.char)(rxPtr), (C.uint)(count))
 
 	if gpioCS {
 		chipPin, err := s.bus.pi.GPIOPinByName(chipSelect)


### PR DESCRIPTION
Refactor piID to C.int type within struct. This makes subsequent function calls cleaner because no casting is needed.

Example:
- `C.pigpio_stop(pi.piID)` instead of `C.pigpio_stop(C.int(pi.piID))`