### PR TITLE
Rsdk-8376: refactor part-1

### DIFF
--- a/rpi-servo/rpiservo.go
+++ b/rpi-servo/rpiservo.go
@@ -19,7 +19,6 @@ package rpiservo
 
 // #include <stdlib.h>
 // #include <pigpiod_if2.h>
-// #cgo LDFLAGS: -lpigpio
 // #include "../rpi/pi.h"
 import "C"
 

--- a/rpi/gpio.go
+++ b/rpi/gpio.go
@@ -9,7 +9,6 @@ package rpi
 // #include <stdlib.h>
 // #include <pigpiod_if2.h>
 // #include "pi.h"
-// #cgo LDFLAGS: -lpigpio
 import "C"
 
 import (

--- a/rpi/interrupts.go
+++ b/rpi/interrupts.go
@@ -9,7 +9,6 @@ package rpi
 // #include <stdlib.h>
 // #include <pigpiod_if2.h>
 // #include "pi.h"
-// #cgo LDFLAGS: -lpigpio
 import "C"
 
 import (

--- a/rpi/rpi.go
+++ b/rpi/rpi.go
@@ -17,7 +17,6 @@ package rpi
 // #include <stdlib.h>
 // #include <pigpiod_if2.h>
 // #include "pi.h"
-// #cgo LDFLAGS: -lpigpio
 import "C"
 
 import (

--- a/rpi/spi.go
+++ b/rpi/spi.go
@@ -10,7 +10,6 @@ package rpi
 // #include <stdlib.h>
 // #include <pigpiod_if2.h>
 // #include "pi.h"
-// #cgo LDFLAGS: -lpigpio
 import "C"
 
 import (


### PR DESCRIPTION
Refactored: 
- `newPiServo` into smaller helper functions. 
- broke down `reconfigureInterrupts` into other helper functions.
- `Close()` in `rpi.go` into smaller functions. 