### PR TITLE
working CI runner config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,6 @@ jobs:
           git init
           git add .
           chown -R testbot:testbot .
-          sudo -u testbot bash -lc 'go env'
           sudo -u testbot bash -lc 'make lint'
           if [ -n "$GEN_DIFF" ]; then
               echo '"make lint" resulted in changes not in git' 1>&2


### PR DESCRIPTION
## What changed
- remove strategy/matrix (wasn't being used)
- set working runs-on + container
- remove apt update step (I think it's not necessary here but could be wrong)
## Notes
- before, it seemed like the system was only running the second-to-last commit to a branch? not totally sure. I suspect a bug in the CI system when the queue of non-assignable is long? I fixed by canceling all the pending jobs, not really sure what was happening though
- this can't use the setup-go action, but if it could, it would run faster