### PR TITLE
Move docker image to older bullseye base

### DIFF
--- a/.canon.yaml
+++ b/.canon.yaml
@@ -3,7 +3,7 @@ pi:
     default: true
     arch: arm64
     image_arm64: ghcr.io/viam-modules/raspberry-pi:arm64
-    minimum_date: 2024-08-01T00:00:00.0Z
+    minimum_date: 2024-08-21T00:00:00.0Z
     update_interval: 168h0m0s
     user: testbot
     group: testbot

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ lint: $(TOOL_BIN)/golangci-lint
 
 .PHONY: docker
 docker:
-	cd docker && docker buildx build --load --no-cache --platform linux/arm64 -t ghcr.io/viam-modules/raspberry-pi:arm64
+	cd docker && docker buildx build --load --no-cache --platform linux/arm64 -t ghcr.io/viam-modules/raspberry-pi:arm64 .
 
 .PHONY: docker-upload
 docker-upload:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
-FROM debian:bookworm
+FROM debian:bullseye
 
-ARG GO_VERSION=1.21
+ARG GO_VERSION=1.23.0
 
 # Backports repo
 RUN echo "deb http://deb.debian.org/debian $(grep VERSION_CODENAME /etc/os-release | cut -d= -f2)-backports main" > /etc/apt/sources.list.d/backports.list
@@ -8,10 +8,11 @@ RUN echo "deb http://deb.debian.org/debian $(grep VERSION_CODENAME /etc/os-relea
 RUN --mount=type=cache,target=/var/cache/apt apt-get update
 RUN --mount=type=cache,target=/var/cache/apt \
     apt-get install -qqy \
-    golang-${GO_VERSION}-go git make curl gpg wget sudo nano file procps bash
+    git build-essential make curl gpg wget sudo nano file procps bash
 
-RUN update-alternatives --install /usr/bin/go go /usr/lib/go-${GO_VERSION}/bin/go 10 \
-    --slave /usr/bin/gofmt gofmt /usr/lib/go-${GO_VERSION}/bin/gofmt
+RUN curl -L https://go.dev/dl/go${GO_VERSION}.linux-arm64.tar.gz | tar -xzv -C /usr/local && \
+    update-alternatives --install /usr/bin/go go /usr/local/go/bin/go 10 \
+    --slave /usr/bin/gofmt gofmt /usr/local/go/bin/gofmt
 
 #Raspberry Pi repo
 RUN curl http://archive.raspberrypi.org/debian/raspberrypi.gpg.key -o /etc/apt/trusted.gpg.d/raspberrypi.asc && echo "deb http://archive.raspberrypi.com/debian $(grep VERSION_CODENAME /etc/os-release | cut -d= -f2) main" > /etc/apt/sources.list.d/raspi.list


### PR DESCRIPTION
Already built and pushed the image. The .canon.yaml change will force updates the next time someone uses canon (after this merge) and then you can build with the new bullseye base.