### PR TITLE
auto-detect golang version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ BIN_OUTPUT_PATH = bin
 TOOL_BIN = bin/gotools/$(shell uname -s)-$(shell uname -m)
 ARM64_OUTPUT = $(BIN_OUTPUT_PATH)/raspberry-pi/arm64
 ARM32_OUTPUT = $(BIN_OUTPUT_PATH)/raspberry-pi/arm32
+DOCKER_ARCH ?= arm64
+
 .PHONY: module
 module: build
 	rm -f $(BIN_OUTPUT_PATH)/raspberry-pi-module.tar.gz
@@ -43,7 +45,7 @@ lint: $(TOOL_BIN)/golangci-lint
 
 .PHONY: docker
 docker:
-	cd docker && docker buildx build --load --no-cache --platform linux/arm64 -t ghcr.io/viam-modules/raspberry-pi:arm64 .
+	cd docker && docker buildx build --load --no-cache --platform linux/$(DOCKER_ARCH) -t ghcr.io/viam-modules/raspberry-pi:$(DOCKER_ARCH) .
 
 .PHONY: docker-upload
 docker-upload:
@@ -55,4 +57,3 @@ setup:
 
 clean:
 	rm -rf $(BIN_OUTPUT_PATH)
-	

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye
 
-ARG GO_VERSION=1.23.0
+ARG GO_VERSION=1.23.2
 
 # Backports repo
 RUN echo "deb http://deb.debian.org/debian $(grep VERSION_CODENAME /etc/os-release | cut -d= -f2)-backports main" > /etc/apt/sources.list.d/backports.list
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
     apt-get install -qqy \
     git build-essential make curl gpg wget sudo nano file procps bash
 
-RUN curl -L https://go.dev/dl/go${GO_VERSION}.linux-arm64.tar.gz | tar -xzv -C /usr/local && \
+RUN curl -L https://go.dev/dl/go${GO_VERSION}.linux-$(if [ `dpkg --print-architecture` = arm64 ]; then echo arm64; else echo armv6l; fi).tar.gz | tar -xzv -C /usr/local && \
     update-alternatives --install /usr/bin/go go /usr/local/go/bin/go 10 \
     --slave /usr/bin/gofmt gofmt /usr/local/go/bin/gofmt
 


### PR DESCRIPTION
## What changed
- use `dpkg --print-architecture` to auto-select 32/64 bit golang installation
## Why
64-bit go misbehaves in armhf container.