### PR TITLE
[RSDK-9071] track the state of gpio pins

### DIFF
--- a/rpi/board.go
+++ b/rpi/board.go
@@ -181,6 +181,12 @@ func (pi *piPigpio) Reconfigure(
 		return err
 	}
 
+	for _, c := range cfg.Pins {
+		if c.Name == "" {
+			c.Name = c.Pin
+		}
+	}
+
 	pi.mu.Lock()
 	defer pi.mu.Unlock()
 

--- a/rpi/board.go
+++ b/rpi/board.go
@@ -180,7 +180,7 @@ func (pi *piPigpio) Reconfigure(
 	if err != nil {
 		return err
 	}
-
+	// make sure every pin has a name. We already know every pin has a pin
 	for _, c := range cfg.Pins {
 		if c.Name == "" {
 			c.Name = c.Pin

--- a/rpi/board.go
+++ b/rpi/board.go
@@ -86,8 +86,7 @@ type piPigpio struct {
 	mu            sync.Mutex
 	cancelCtx     context.Context
 	cancelFunc    context.CancelFunc
-	duty          int // added for mutex
-	gpioConfigSet map[int]bool
+	gpioPins      map[int]*rpiGPIO
 	analogReaders map[string]*pinwrappers.AnalogSmoother
 	// `interrupts` maps interrupt names to the interrupts. `interruptsHW` maps broadcom addresses
 	// to these same values. The two should always have the same set of values.
@@ -186,6 +185,10 @@ func (pi *piPigpio) Reconfigure(
 	defer pi.mu.Unlock()
 
 	if err := pi.reconfigureAnalogReaders(cfg); err != nil {
+		return err
+	}
+
+	if err := pi.reconfigureGPIOs(ctx, cfg); err != nil {
 		return err
 	}
 

--- a/rpi/board_test.go
+++ b/rpi/board_test.go
@@ -22,6 +22,7 @@ func TestPiPigpio(t *testing.T) {
 		Pins: []rpiutils.PinConfig{
 			{Name: "i1", Pin: "11", Type: "interrupt"}, // bcom 17
 			{Name: "servo-i", Pin: "22", Type: "interrupt"},
+			{Name: "blue", Pin: "33", Type: "gpio"},
 		},
 	}
 	resourceConfig := resource.Config{
@@ -94,6 +95,39 @@ func TestPiPigpio(t *testing.T) {
 		vI, err = pin.PWMFreq(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, vI, test.ShouldEqual, 8000)
+	})
+
+	t.Run("gpio pins respect names and can use hardware name", func(t *testing.T) {
+		// blue, pin33, and io13 are all the same pin
+		pinBlue, err := p.GPIOPinByName("blue")
+		test.That(t, err, test.ShouldBeNil)
+		pin33, err := p.GPIOPinByName("33")
+		test.That(t, err, test.ShouldBeNil)
+		pinIO13, err := p.GPIOPinByName("io13")
+		test.That(t, err, test.ShouldBeNil)
+		// pin 35 is a different pin
+		diffPin, err := p.GPIOPinByName("35")
+		test.That(t, err, test.ShouldBeNil)
+
+		// try to set high
+		err = pinBlue.Set(ctx, true, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		v, err := pinBlue.Get(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, v, test.ShouldEqual, true)
+
+		v, err = pin33.Get(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, v, test.ShouldEqual, true)
+
+		v, err = pinIO13.Get(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, v, test.ShouldEqual, true)
+
+		v, err = diffPin.Get(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, v, test.ShouldEqual, false)
 	})
 
 	// interrupt is configured on pi board creation

--- a/rpi/gpio.go
+++ b/rpi/gpio.go
@@ -14,10 +14,11 @@ import (
 	"context"
 	"fmt"
 
+	rpiutils "raspberry-pi/utils"
+
 	"github.com/pkg/errors"
 	"go.viam.com/rdk/components/board"
 	rdkutils "go.viam.com/rdk/utils"
-	rpiutils "raspberry-pi/utils"
 )
 
 // GPIOConfig tracks what each pin is currently configured as
@@ -153,6 +154,7 @@ func (pi *piPigpio) SetGPIOBcom(bcom int, high bool) error {
 			if res != 0 {
 				return errors.Errorf("pwm set fail %d", res)
 			}
+			pin.pwmEnabled = false
 		}
 		res := C.set_mode(pi.piID, C.uint(pin.pin), C.PI_OUTPUT)
 		if res != 0 {

--- a/rpi/gpio.go
+++ b/rpi/gpio.go
@@ -12,6 +12,7 @@ import "C"
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"go.viam.com/rdk/components/board"
@@ -19,14 +20,49 @@ import (
 	rpiutils "raspberry-pi/utils"
 )
 
+// GPIOConfig tracks what each pin is currently configured as
+type GPIOConfig int
+
+const (
+	GPIODefault   GPIOConfig = iota // GPIODefault is the default pin state, before we have modified the pin
+	GPIOInput                       // GPIOInput is the default pin state, before we have modified the pin
+	GPIOOutput                      // GPIOOutput is the default pin state, before we have modified the pin
+	GPIOPWM                         // GPIOPWM is the default pin state, before we have modified the pin
+	GPIOInterrupt                   // GPIOInterrupt is the default pin state, before we have modified the pin
+)
+
+type rpiGPIO struct {
+	name          string
+	pin           uint
+	configuration GPIOConfig
+}
+
 // GPIOPinByName returns a GPIOPin by name.
 func (pi *piPigpio) GPIOPinByName(pin string) (board.GPIOPin, error) {
 	pi.mu.Lock()
 	defer pi.mu.Unlock()
+
 	bcom, have := rpiutils.BroadcomPinFromHardwareLabel(pin)
+
+	// check if we have already configured the pin
+	for _, configuredPin := range pi.gpioPins {
+		pi.logger.Warn("check pin: ", configuredPin.name)
+		if configuredPin.name == pin {
+			return gpioPin{pi, int(configuredPin.pin)}, nil
+		}
+		// check if the pin was configured with a different name
+		if have && configuredPin.pin == bcom {
+			pi.logger.Warnf("pin %v has already been configured with name %v", pin, configuredPin.name)
+			return gpioPin{pi, int(configuredPin.pin)}, nil
+		}
+	}
 	if !have {
 		return nil, errors.Errorf("no hw pin for (%s)", pin)
 	}
+
+	// the pin was not found, so add a new pin to the map
+	pi.gpioPins[int(bcom)] = &rpiGPIO{pin: bcom, name: pin}
+
 	return gpioPin{pi, int(bcom)}, nil
 }
 
@@ -59,20 +95,49 @@ func (gp gpioPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]
 	return gp.pi.SetPWMFreqBcom(gp.bcom, freqHz)
 }
 
+func (pi *piPigpio) reconfigureGPIOs(ctx context.Context, cfg *Config) error {
+	// Set new pins based on config
+	pi.gpioPins = map[int]*rpiGPIO{}
+	for _, newConfig := range cfg.Pins {
+		if newConfig.Type != rpiutils.PinGPIO {
+			continue
+		}
+		bcom, have := rpiutils.BroadcomPinFromHardwareLabel(newConfig.Pin)
+		if !have {
+			return errors.Errorf("no hw pin for (%s)", newConfig.Pin)
+		}
+		pin := &rpiGPIO{name: newConfig.Name, pin: bcom}
+		pi.gpioPins[int(bcom)] = pin
+		pi.logger.Warn("yo pin: ", pin.name)
+	}
+	return nil
+}
+
 // GetGPIOBcom gets the level of the given broadcom pin
 func (pi *piPigpio) GetGPIOBcom(bcom int) (bool, error) {
 	pi.mu.Lock()
 	defer pi.mu.Unlock()
-	if !pi.gpioConfigSet[bcom] {
-		if pi.gpioConfigSet == nil {
-			pi.gpioConfigSet = map[int]bool{}
+
+	// verify we are currently managing this pin via GPIOPinByName or reconfigure
+	pin, ok := pi.gpioPins[bcom]
+	if !ok {
+		return false, fmt.Errorf("error getting GPIO pin, pin %v not found", bcom)
+	}
+	// configure the pin to be an input if it is not already an input
+	if pin.configuration != GPIOInput {
+		// first if the pin was configured for pwm, we should turn off the pwm
+		if pin.configuration == GPIOPWM {
+			res := C.set_PWM_dutycycle(pi.piID, C.uint(pin.pin), C.uint(0))
+			if res != 0 {
+				return false, errors.Errorf("pwm set fail %d", res)
+			}
 		}
-		res := C.set_mode(pi.piID, C.uint(bcom), C.PI_INPUT)
+		res := C.set_mode(pi.piID, C.uint(pin.pin), C.PI_INPUT)
 		if res != 0 {
 			return false, rpiutils.ConvertErrorCodeToMessage(int(res), "failed to set mode")
 		}
-		pi.gpioConfigSet[bcom] = true
 	}
+	pin.configuration = GPIOInput
 
 	// gpioRead retrns an int 1 or 0, we convert to a bool
 	return C.gpio_read(pi.piID, C.uint(bcom)) != 0, nil
@@ -82,27 +147,47 @@ func (pi *piPigpio) GetGPIOBcom(bcom int) (bool, error) {
 func (pi *piPigpio) SetGPIOBcom(bcom int, high bool) error {
 	pi.mu.Lock()
 	defer pi.mu.Unlock()
-	if !pi.gpioConfigSet[bcom] {
-		if pi.gpioConfigSet == nil {
-			pi.gpioConfigSet = map[int]bool{}
+
+	// verify we are currently managing this pin via GPIOPinByName or reconfigure
+	pin, ok := pi.gpioPins[bcom]
+	if !ok {
+		return fmt.Errorf("error getting GPIO pin, pin %v not found", bcom)
+	}
+	// configure the pin to be an output if it is not already an output
+	if pin.configuration != GPIOOutput {
+		// first if the pin was configured for pwm, we should turn off the pwm
+		if pin.configuration == GPIOPWM {
+			res := C.set_PWM_dutycycle(pi.piID, C.uint(pin.pin), C.uint(0))
+			if res != 0 {
+				return errors.Errorf("pwm set fail %d", res)
+			}
 		}
-		res := C.set_mode(pi.piID, C.uint(bcom), C.PI_OUTPUT)
+		res := C.set_mode(pi.piID, C.uint(pin.pin), C.PI_OUTPUT)
 		if res != 0 {
 			return rpiutils.ConvertErrorCodeToMessage(int(res), "failed to set mode")
 		}
-		pi.gpioConfigSet[bcom] = true
 	}
 
 	v := 0
 	if high {
 		v = 1
 	}
-	C.gpio_write(pi.piID, C.uint(bcom), C.uint(v))
+	C.gpio_write(pi.piID, C.uint(pin.pin), C.uint(v))
+
 	return nil
 }
 
 func (pi *piPigpio) pwmBcom(bcom int) (float64, error) {
-	res := C.get_PWM_dutycycle(pi.piID, C.uint(bcom))
+	// verify we are currently managing this pin via GPIOPinByName or reconfigure
+	pin, ok := pi.gpioPins[bcom]
+	if !ok {
+		return 0, fmt.Errorf("error getting GPIO pin, pin %v not found", bcom)
+	}
+	if pin.configuration != GPIOPWM {
+		pi.logger.Debugf("pin %v is currently not configured as pwm", bcom)
+		return 0, nil
+	}
+	res := C.get_PWM_dutycycle(pi.piID, C.uint(pin.pin))
 	return float64(res) / 255, nil
 }
 
@@ -110,11 +195,17 @@ func (pi *piPigpio) pwmBcom(bcom int) (float64, error) {
 func (pi *piPigpio) SetPWMBcom(bcom int, dutyCyclePct float64) error {
 	pi.mu.Lock()
 	defer pi.mu.Unlock()
-	dutyCycle := rdkutils.ScaleByPct(255, dutyCyclePct)
-	pi.duty = int(C.set_PWM_dutycycle(pi.piID, C.uint(bcom), C.uint(dutyCycle)))
-	if pi.duty != 0 {
-		return errors.Errorf("pwm set fail %d", pi.duty)
+	pin, ok := pi.gpioPins[bcom]
+	if !ok {
+		return fmt.Errorf("error getting GPIO pin, pin %v not found", bcom)
 	}
+
+	dutyCycle := rdkutils.ScaleByPct(255, dutyCyclePct)
+	res := C.set_PWM_dutycycle(pi.piID, C.uint(pin.pin), C.uint(dutyCycle))
+	if res != 0 {
+		return errors.Errorf("pwm set fail %d", res)
+	}
+	pin.configuration = GPIOPWM
 	return nil
 }
 

--- a/rpi/gpio.go
+++ b/rpi/gpio.go
@@ -14,10 +14,11 @@ import (
 	"context"
 	"fmt"
 
+	rpiutils "raspberry-pi/utils"
+
 	"github.com/pkg/errors"
 	"go.viam.com/rdk/components/board"
 	rdkutils "go.viam.com/rdk/utils"
-	rpiutils "raspberry-pi/utils"
 )
 
 // GPIOConfig tracks what each pin is currently configured as
@@ -25,10 +26,10 @@ type GPIOConfig int
 
 const (
 	GPIODefault   GPIOConfig = iota // GPIODefault is the default pin state, before we have modified the pin
-	GPIOInput                       // GPIOInput is the default pin state, before we have modified the pin
-	GPIOOutput                      // GPIOOutput is the default pin state, before we have modified the pin
-	GPIOPWM                         // GPIOPWM is the default pin state, before we have modified the pin
-	GPIOInterrupt                   // GPIOInterrupt is the default pin state, before we have modified the pin
+	GPIOInput                       // GPIOInput is when a pin is configured as a digital input
+	GPIOOutput                      // GPIOOutput is when the pin is configured as a digital output
+	GPIOPWM                         // GPIOPWM is when the pin is configured as pwm
+	GPIOInterrupt                   // GPIOInterrupt is the pin is configured as an interrupt
 )
 
 type rpiGPIO struct {
@@ -46,7 +47,6 @@ func (pi *piPigpio) GPIOPinByName(pin string) (board.GPIOPin, error) {
 
 	// check if we have already configured the pin
 	for _, configuredPin := range pi.gpioPins {
-		pi.logger.Warn("check pin: ", configuredPin.name)
 		if configuredPin.name == pin {
 			return gpioPin{pi, int(configuredPin.pin)}, nil
 		}
@@ -108,7 +108,6 @@ func (pi *piPigpio) reconfigureGPIOs(ctx context.Context, cfg *Config) error {
 		}
 		pin := &rpiGPIO{name: newConfig.Name, pin: bcom}
 		pi.gpioPins[int(bcom)] = pin
-		pi.logger.Warn("yo pin: ", pin.name)
 	}
 	return nil
 }

--- a/utils/digital_interrupts.go
+++ b/utils/digital_interrupts.go
@@ -57,11 +57,11 @@ func (pull Pull) Validate() error {
 
 // Validate ensures all parts of the config are valid.
 func (config *PinConfig) Validate(path string) error {
-	if config.Name == "" {
-		return resource.NewConfigValidationFieldRequiredError(path, "name")
-	}
 	if config.Pin == "" {
 		return resource.NewConfigValidationFieldRequiredError(path, "pin")
+	}
+	if config.Name == "" {
+		config.Name = config.Pin
 	}
 	if err := config.PullState.Validate(); err != nil {
 		return err

--- a/utils/digital_interrupts.go
+++ b/utils/digital_interrupts.go
@@ -60,9 +60,6 @@ func (config *PinConfig) Validate(path string) error {
 	if config.Pin == "" {
 		return resource.NewConfigValidationFieldRequiredError(path, "pin")
 	}
-	if config.Name == "" {
-		config.Name = config.Pin
-	}
 	if err := config.PullState.Validate(); err != nil {
 		return err
 	}


### PR DESCRIPTION
this pr adds the ability to use pin names for gpio pins and attempts to prevent pigpio from configuring pins into unexpected states(i.e. pwms still running while setting a digital output on a pin)

https://viam.atlassian.net/browse/RSDK-9071