### PR TITLE
[RSDK-9257] Add gpio and interrupt configuration via config for pi5

### DIFF
--- a/etc/.golangci.yaml
+++ b/etc/.golangci.yaml
@@ -63,6 +63,9 @@ linters-settings:
   gofumpt:
     lang-version: "1.21"
     extra-rules: true
+  gosec:
+    excludes:
+      - G115
   govet:
     enable-all: true
     disable:

--- a/etc/.golangci.yaml
+++ b/etc/.golangci.yaml
@@ -61,7 +61,7 @@ linters-settings:
       - standard
       - default
   gofumpt:
-    lang-version: "1.21"
+    lang-version: "1.23"
     extra-rules: true
   gosec:
     excludes:

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golangci/golangci-lint v1.61.0
 	github.com/pkg/errors v0.9.1
 	github.com/rhysd/actionlint v1.6.24
-	github.com/viam-modules/pinctrl v0.0.0-20241122191654-83914270ceff
+	github.com/viam-modules/pinctrl v0.0.0-20241206221207-94ef717afa64
 	go.uber.org/multierr v1.11.0
 	go.viam.com/api v0.1.357
 	go.viam.com/rdk v0.50.0

--- a/go.sum
+++ b/go.sum
@@ -1255,8 +1255,8 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasthttp v1.16.0/go.mod h1:YOKImeEosDdBPnxc0gy7INqi3m1zK6A+xl6TwOBhHCA=
 github.com/valyala/quicktemplate v1.6.3/go.mod h1:fwPzK2fHuYEODzJ9pkw0ipCPNHZ2tD5KW4lOuSdPKzY=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
-github.com/viam-modules/pinctrl v0.0.0-20241122191654-83914270ceff h1:+2/e59WKCVlaZsZrOPr3nY/rif+KeEVwK9lFZRVz1hk=
-github.com/viam-modules/pinctrl v0.0.0-20241122191654-83914270ceff/go.mod h1:klkE1Ll5blcoLTi8abPsujXNyLOY0cte5tHYOjTo5u8=
+github.com/viam-modules/pinctrl v0.0.0-20241206221207-94ef717afa64 h1:cITm4d6fKsvPyCk7elRqqLdDgQoXYA80N8y9IHUMseo=
+github.com/viam-modules/pinctrl v0.0.0-20241206221207-94ef717afa64/go.mod h1:klkE1Ll5blcoLTi8abPsujXNyLOY0cte5tHYOjTo5u8=
 github.com/viamrobotics/evdev v0.1.3 h1:mR4HFafvbc5Wx4Vp1AUJp6/aITfVx9AKyXWx+rWjpfc=
 github.com/viamrobotics/evdev v0.1.3/go.mod h1:N6nuZmPz7HEIpM7esNWwLxbYzqWqLSZkfI/1Sccckqk=
 github.com/viamrobotics/webrtc/v3 v3.99.10 h1:ykE14wm+HkqMD5Ozq4rvhzzfvnXAu14ak/HzA1OCzfY=

--- a/pi5/board.go
+++ b/pi5/board.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	rpiutils "raspberry-pi/utils"
+
 	"github.com/pkg/errors"
 	"github.com/viam-modules/pinctrl/pinctrl"
 	"go.uber.org/multierr"
@@ -21,7 +23,6 @@ import (
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/utils"
-	rpiutils "raspberry-pi/utils"
 )
 
 // Model is the model for a Raspberry Pi 5.
@@ -153,13 +154,14 @@ func (b *pinctrlpi5) Reconfigure(
 	defer b.mu.Unlock()
 
 	// make sure every pin has a name. We already know every pin has a pin
+	// possibly clean this up at a later date
 	for _, c := range newConf.Pins {
 		if c.Name == "" {
 			c.Name = c.Pin
 		}
 	}
 
-	if err := b.addUserDefinedNames(newConf); err != nil {
+	if err := b.validatePins(newConf); err != nil {
 		return err
 	}
 
@@ -228,7 +230,7 @@ func (b *pinctrlpi5) reconfigureInterrupts(newConf *rpiutils.Config) error {
 }
 
 // record all custom pin names that the user has defined in the config for lookup.
-func (b *pinctrlpi5) addUserDefinedNames(newConf *rpiutils.Config) error {
+func (b *pinctrlpi5) validatePins(newConf *rpiutils.Config) error {
 	nameToPin := map[string]uint{}
 	for _, pinConf := range newConf.Pins {
 		// ensure the configured pin is a real pin

--- a/pi5/board.go
+++ b/pi5/board.go
@@ -231,15 +231,15 @@ func (b *pinctrlpi5) reconfigureInterrupts(newConf *rpiutils.Config) error {
 func (b *pinctrlpi5) addUserDefinedNames(newConf *rpiutils.Config) error {
 	nameToPin := map[string]uint{}
 	for _, pinConf := range newConf.Pins {
-		// check if the pin name matches a name we handle by default
-		_, alreadyDefined := rpiutils.BroadcomPinFromHardwareLabel(pinConf.Name)
-		if alreadyDefined {
-			continue
-		}
 		// ensure the configured pin is a real pin
 		pin, ok := b.gpioMappings[pinConf.Pin]
 		if !ok {
 			return fmt.Errorf("pin %v could not be found", pinConf.Pin)
+		}
+		// check if the pin name matches a name we handle by default
+		_, alreadyDefined := rpiutils.BroadcomPinFromHardwareLabel(pinConf.Name)
+		if alreadyDefined {
+			continue
 		}
 		// add the new name to our list of names to track
 		nameToPin[pinConf.Name] = uint(pin.GPIO)

--- a/pi5/board_test.go
+++ b/pi5/board_test.go
@@ -6,12 +6,11 @@ import (
 	"context"
 	"testing"
 
-	rpiutils "raspberry-pi/utils"
-
 	"go.viam.com/rdk/components/board/genericlinux"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/test"
+	rpiutils "raspberry-pi/utils"
 )
 
 func TestEmptyBoard(t *testing.T) {

--- a/rpi/gpio.go
+++ b/rpi/gpio.go
@@ -14,11 +14,10 @@ import (
 	"context"
 	"fmt"
 
-	rpiutils "raspberry-pi/utils"
-
 	"github.com/pkg/errors"
 	"go.viam.com/rdk/components/board"
 	rdkutils "go.viam.com/rdk/utils"
+	rpiutils "raspberry-pi/utils"
 )
 
 // GPIOConfig tracks what each pin is currently configured as

--- a/rpi/gpio.go
+++ b/rpi/gpio.go
@@ -14,10 +14,11 @@ import (
 	"context"
 	"fmt"
 
+	rpiutils "raspberry-pi/utils"
+
 	"github.com/pkg/errors"
 	"go.viam.com/rdk/components/board"
 	rdkutils "go.viam.com/rdk/utils"
-	rpiutils "raspberry-pi/utils"
 )
 
 // GPIOConfig tracks what each pin is currently configured as
@@ -213,7 +214,7 @@ func (pi *piPigpio) SetPWMFreqBcom(bcom int, freqHz uint) error {
 	pi.mu.Lock()
 	defer pi.mu.Unlock()
 	if freqHz == 0 {
-		freqHz = 800 // Original default from libpigpio
+		freqHz = rpiutils.DefaultPWMFreqHz
 	}
 	newRes := C.set_PWM_frequency(pi.piID, C.uint(bcom), C.uint(freqHz))
 

--- a/utils/broadcom.go
+++ b/utils/broadcom.go
@@ -4,7 +4,7 @@ package rpiutils
 import "fmt"
 
 // DefaultPWMFreqHz is the default pwm frequency used for pwms on raspberry pis.
-// Original default from libpigpio
+// Original default from libpigpio.
 const DefaultPWMFreqHz = uint(800)
 
 // piHWPinToBroadcom maps the hardware inscribed pin number to

--- a/utils/broadcom.go
+++ b/utils/broadcom.go
@@ -3,6 +3,10 @@ package rpiutils
 
 import "fmt"
 
+// DefaultPWMFreqHz is the default pwm frequency used for pwms on raspberry pis.
+// Original default from libpigpio
+const DefaultPWMFreqHz = uint(800)
+
 // piHWPinToBroadcom maps the hardware inscribed pin number to
 // its Broadcom pin. For the sake of programming, a user typically
 // knows the hardware pin since they have the board on hand but does

--- a/utils/broadcom.go
+++ b/utils/broadcom.go
@@ -66,10 +66,12 @@ var piHWPinToBroadcom = map[string]uint{
 // BroadcomPinFromHardwareLabel returns a Raspberry Pi pin number given
 // a hardware label for the pin passed from a config.
 func BroadcomPinFromHardwareLabel(hwPin string) (uint, bool) {
+	// check if we were given a hardware pin & return the broadcom label if so
 	pin, ok := piHWPinToBroadcom[hwPin]
 	if ok {
 		return pin, true
 	}
+	// if we weren't given a hardware pin, check if we were given a broadcom label
 	for _, existingVal := range piHWPinToBroadcom {
 		if hwPin == fmt.Sprintf("io%d", existingVal) {
 			return existingVal, true


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-9257

This pr allows users to configure digital interrupts and gpios through the pi5 config. It also allows users to define custom names for pins and use hardware pins and pin labels interchangeably, to match the behavior of the pi4 model.

The implementation took abit longer than I expected, as the model did not have configure/reconfigure logic for interrupts yet

tested on a pi 5 with multiple interrupts, with reconfigure