### PR TITLE
Issue #65 - Fix invalid JSON and markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This module implements the [`rdk:component:board` API](https://docs.viam.com/components/board/#api) and [`rdk:component:servo` API](https://docs.viam.com/components/servo/#api)
 
 The following models are provided in this module:
+
 * `viam:raspberry-pi:rpi5` - Configure a Raspberry Pi 5 board to access GPIO functionality: input, output, PWM, power, serial interfaces, etc.
 * `viam:raspberry-pi:rpi4` - Configure a Raspberry Pi 4 board
 * `viam:raspberry-pi:rpi3` - Configure a Raspberry Pi 3 board
@@ -24,7 +25,6 @@ Fill in the attributes as applicable to your board:
 
 ```json
 {
-  {
   "components": [
     {
       "name": "<your-pi-board-name>",
@@ -49,9 +49,9 @@ Fill in the attributes as applicable to your board:
             "type": "<gpio/interrupt>"
           }
         ]
-      },
+      }
     }
-  ]
+  ],
   "modules": [
     {
       "type": "registry",
@@ -59,7 +59,7 @@ Fill in the attributes as applicable to your board:
       "module_id": "viam:raspberry-pi",
       "version": "^1"
     }
-  ],
+  ]
 }
 ```
 
@@ -80,7 +80,7 @@ ADCs are useful when building a robot, as they enable your board to read the ana
 
 To integrate an ADC into your machine, you must first physically connect the pins on your ADC to your board. The Pi 5 board does not currently support the use of analogs.
 
-Then, integrate `analogs` into the `attributes` of your board by following the **Config Builder** instructions or by adding the following to your board’s JSON configuration:
+Then, integrate `analogs` into the `attributes` of your board by following the **Config Builder** instructions or by adding the following to your board's JSON configuration:
 
 ```json
 // "attributes": { ... ,
@@ -101,7 +101,7 @@ The following properties are available for `analogs`:
 | Name | Type | Required? | Description |
 | ---- | ---- | --------- | ----------- |
 | `name` | string | **Required** | Your name for the analog reader. |
-| `pin` | string | **Required** | The pin number of the ADC's connection pin, wired to the board. This should be labeled as the physical index of the pin on the ADC.
+| `pin` | string | **Required** | The pin number of the ADC's connection pin, wired to the board. This should be labeled as the physical index of the pin on the ADC. |
 | `chip_select` | string | **Required** | The chip select index of the board's connection pin, wired to the ADC. |
 | `spi_bus` | string | **Required** | The index of the SPI bus connecting the ADC and board. |
 | `average_over_ms` | int | Optional | Duration in milliseconds over which the rolling average of the analog input should be taken. |
@@ -141,10 +141,10 @@ Example:
 
 Pins can be configured as GPIO pins and interrupts. [Interrupts](https://en.wikipedia.org/wiki/Interrupt) are a method of signaling precise state changes. Configuring digital interrupts to monitor GPIO pins on your board is useful when your application needs to know precisely when there is a change in GPIO value between high and low.
 
-- When an interrupt configured on your board processes a change in the state of the GPIO pin it is configured to monitor, it ticks to record the state change. You can stream these ticks with the board API’s [`StreamTicks()`](https://docs.viam.com/components/board/#streamticks), or get the current value of the digital interrupt with Value().
-- Calling [`GetGPIO()`](https://docs.viam.com/components/board/#getgpio) on a GPIO pin, which you can do without configuring interrupts, is useful when you want to know a pin’s value at specific points in your program, but is less precise and convenient than using an interrupt.
+* When an interrupt configured on your board processes a change in the state of the GPIO pin it is configured to monitor, it ticks to record the state change. You can stream these ticks with the board API's [`StreamTicks()`](https://docs.viam.com/components/board/#streamticks), or get the current value of the digital interrupt with Value().
+* Calling [`GetGPIO()`](https://docs.viam.com/components/board/#getgpio) on a GPIO pin, which you can do without configuring interrupts, is useful when you want to know a pin's value at specific points in your program, but is less precise and convenient than using an interrupt.
 
-Integrate `pins` into your machine in the `attributes` of your board by following the **Config Builder** instructions, or by adding the following to your board’s JSON configuration:
+Integrate `pins` into your machine in the `attributes` of your board by following the **Config Builder** instructions, or by adding the following to your board's JSON configuration:
 
 ```json
 // "attributes": { ... ,
@@ -158,6 +158,7 @@ Integrate `pins` into your machine in the `attributes` of your board by followin
 ```
 
 The following properties are available for `pins`:
+
 | Name | Type | Required? | Description |
 | ---- | ---- | --------- | ----------- |
 |`name` | string | **Required** | Your name for the digital interrupt. |
@@ -206,9 +207,11 @@ Example:
 ```
 
 ### Additional Info for Dev
-This module uses Viam's [genericlinux implementation](https://github.com/viamrobotics/rdk/tree/main/components/board/genericlinux) for SPI and I2C. 
+
+This module uses Viam's [genericlinux implementation](https://github.com/viamrobotics/rdk/tree/main/components/board/genericlinux) for SPI and I2C.
 
 ## Configure your pi servo
+
 Navigate to the **CONFIGURE** tab of your machine's page in the [Viam app](https://app.viam.com), searching for `rpi-servo`
 
 Fill in the attributes as applicable to your servo, according to the example below.
@@ -244,8 +247,7 @@ Fill in the attributes as applicable to your servo, according to the example bel
 }
 ```
 
-### Attributes
-
+### Servo attributes
 
 The following attributes are available for `viam:raspberry-pi:rpi-servo` servos:
 
@@ -262,47 +264,62 @@ The following attributes are available for `viam:raspberry-pi:rpi-servo` servos:
 
 ## Local development
 
-### Building 
-Module needs to be built from within `canon`. As of August 2024 this module is being built only in `bullseye` and supports `bullseye` and `bookworm` versions of Debian. 
+### Building
+
+Module needs to be built from within `canon`. As of August 2024 this module is being built only in `bullseye` and supports `bullseye` and `bookworm` versions of Debian.
 `make module` will create raspberry-pi-module.tar.gz.
+
 ```bash
 canon 
 make module
 ```
-Then copy the tar.gz over to your pi 
-```bash 
+
+Then copy the tar.gz over to your pi
+
+```bash
 scp /path-to/raspberry-pi-module.tar.gz your_rpi@pi.local:~
 ```
+
 Now you can use it as a [local module](https://docs.viam.com/how-tos/create-module/#test-your-module-locally)!
 
-### Linting 
-Linting also needs to be done from within `canon` 
+### Linting
+
+Linting also needs to be done from within `canon`
+
 ```bash
 canon 
 make lint
 ```
-### Testing 
+
+### Testing
+
 > [!NOTE]
 >All tests require a functioning raspberry pi4!
 
 Run the following in a pi
+
 ```bash
 make test
 ```
+
 This will create binaries for each test file in /bin and run them.
 
 ## For Devs
+
 ### Module Structure
+
 The directory structure is as follows:
-- `rpi`: Contains all files necessary to define `viam:raspberry-pi:rpi`. Files are organized by functionality.
-- `rpi-servo`: Contains all files necessary to define `viam:raspberry-pi:rpi-servo`. Files are organized by functionality
-- `utils`: Any utility functions that are either universal to the boards or shared between `rpi` and `rpi-servo`. Included are daemon errors, pin mappings, and digital interrupts
-- `testing`: External package exports. Tests the components how an outside package would use the components (w/o any internal functions).
+
+* `rpi`: Contains all files necessary to define `viam:raspberry-pi:rpi`. Files are organized by functionality.
+* `rpi-servo`: Contains all files necessary to define `viam:raspberry-pi:rpi-servo`. Files are organized by functionality
+* `utils`: Any utility functions that are either universal to the boards or shared between `rpi` and `rpi-servo`. Included are daemon errors, pin mappings, and digital interrupts
+* `testing`: External package exports. Tests the components how an outside package would use the components (w/o any internal functions).
 
 ### pigpiod
-The module relies on the pigpio daemon to carry out GPIO functionality. The daemon accepts socket and pipe connections over the local network. Although many things can be configured, from DMA allocation mode to socket port to sample rate, we use the default settings, which match with the traditional pigpio library's defaults. More info can be seen here: https://abyz.me.uk/rpi/pigpio/pigpiod.html.
 
-The daemon essentially supports all the same functionality as the traditional library. Instead of using pigpio.h C library, it uses the daemon library, which is mostly identical: pigpiod_if2.h. Details can be found here: https://abyz.me.uk/rpi/pigpio/pdif2.html
+The module relies on the pigpio daemon to carry out GPIO functionality. The daemon accepts socket and pipe connections over the local network. Although many things can be configured, from DMA allocation mode to socket port to sample rate, we use the default settings, which match with the traditional pigpio library's defaults. More info can be seen here: <https://abyz.me.uk/rpi/pigpio/pigpiod.html>.
+
+The daemon essentially supports all the same functionality as the traditional library. Instead of using pigpio.h C library, it uses the daemon library, which is mostly identical: pigpiod_if2.h. Details can be found here: <https://abyz.me.uk/rpi/pigpio/pdif2.html>
 
 ### Next steps
 


### PR DESCRIPTION
This PR fixes #65 
 - invalid configuration JSON example
 - minor README.MD markdown lint improvements
   - padding around headers
   - trailing whitespace