### PR TITLE
Add I2C enable/disable configuration option with automatic reboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ Navigate to the **CONFIGURE** tab of your machine's page in the [Viam app](https
 
 ## Configure your `raspberry-pi` board
 
-You can copy the following optional attributes to your json if you want to configure `pins` and `analogs`. These are not required to use the Raspberry Pi.
+You can copy the following optional attributes to your json if you want to configure `pins`, `analogs`, and `enable_i2c`. These are not required to use the Raspberry Pi.
 
 ```json
 {
   "pins": [{ }],
-  "analogs": [{ } ]
+  "analogs": [{ } ],
+  "enable_i2c": true
 }
 ```
 
@@ -119,6 +120,36 @@ The following attributes are available for `analogs`:
 | `spi_bus` | string | **Required** | The index of the SPI bus connecting the ADC and board. |
 | `average_over_ms` | int | Optional | Duration in milliseconds over which the rolling average of the analog input should be taken. |
 | `samples_per_sec` | int | Optional | Sampling rate of the analog input in samples per second. |
+
+### `enable_i2c`
+
+The I2C interface on Raspberry Pi is disabled by default. When you set `enable_i2c` to `true`, the module will automatically configure your Raspberry Pi to enable I2C communication.
+
+```json
+{
+  "enable_i2c": true
+}
+```
+
+When I2C is enabled, the module will:
+
+1. Add `dtparam=i2c_arm=on` to `/boot/config.txt` (or `/boot/firmware/config.txt` on newer systems).
+2. Add `i2c-dev` to `/etc/modules` to ensure the I2C device interface is available.
+3. Log the configuration changes for your reference.
+4. **Automatically reboot the system** if changes were made.
+
+**Important Notes:**
+- The system will automatically reboot when I2C configuration changes are made.
+- I2C will be available on GPIO pins 2 & 3 (physical pins 3 & 5) for I2C1 after reboot.
+- The module requires appropriate permissions to modify system configuration files and perform reboot.
+- After the automatic reboot, you can verify I2C is working with `i2cdetect -y 1`.
+- If I2C is already enabled, no reboot will occur.
+
+The following attributes are available for I2C configuration:
+
+| Name | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| `enable_i2c` | boolean | Optional | Enable I2C interface on the Raspberry Pi. Default: `false` |
 
 ## Configure your pi servo
 

--- a/pi5/board.go
+++ b/pi5/board.go
@@ -448,7 +448,7 @@ func (b *pinctrlpi5) configureI2C(cfg *rpiutils.Config) error {
 	if cfg.EnableI2C {
 		configChanged, err = b.updateI2CConfig("on")
 		if err != nil {
-			return fmt.Errorf("failed to enable I2C in /boot/config.txt: %w", err)
+			return fmt.Errorf("failed to enable I2C: %w", err)
 		}
 
 		moduleChanged, err = b.updateI2CModule(true)
@@ -458,7 +458,7 @@ func (b *pinctrlpi5) configureI2C(cfg *rpiutils.Config) error {
 	} else {
 		configChanged, err = b.updateI2CConfig("off")
 		if err != nil {
-			return fmt.Errorf("failed to disable I2C in /boot/config.txt: %w", err)
+			return fmt.Errorf("failed to disable I2C: %w", err)
 		}
 
 		moduleChanged, err = b.updateI2CModule(false)
@@ -472,7 +472,7 @@ func (b *pinctrlpi5) configureI2C(cfg *rpiutils.Config) error {
 		if !cfg.EnableI2C {
 			action = "disabled"
 		}
-		b.logger.Warnf("I2C configuration %s. Initiating automatic reboot in 3 seconds...", action)
+		b.logger.Warnf("I2C configuration %s. Initiating automatic reboot...", action)
 		go rpiutils.PerformReboot(b.logger)
 	}
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -15,6 +15,7 @@ var RaspiFamily = resource.NewModelFamily("viam", "raspberry-pi")
 type Config struct {
 	AnalogReaders []mcp3008helper.MCP3008AnalogConfig `json:"analogs,omitempty"`
 	Pins          []PinConfig                         `json:"pins,omitempty"`
+	EnableI2C     bool                                `json:"enable_i2c,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid.

--- a/utils/file_helpers.go
+++ b/utils/file_helpers.go
@@ -1,0 +1,140 @@
+package rpiutils
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"go.viam.com/rdk/logging"
+)
+
+// UpdateConfigFile atomically updates a configuration file parameter.
+// It handles multiple entries, commented lines, and preserves file permissions
+func UpdateConfigFile(filePath, paramPrefix, desiredValue string, logger logging.Logger) (bool, error) {
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		return false, fmt.Errorf("failed to stat config file %s: %w", filePath, err)
+	}
+
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return false, fmt.Errorf("failed to read config file %s: %w", filePath, err)
+	}
+
+	lines := strings.Split(string(content), "\n")
+	configChanged := false
+	correctEntryExists := false
+	targetLine := paramPrefix + "=" + desiredValue
+	
+	for i, line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+		
+		if strings.HasPrefix(trimmedLine, paramPrefix+"=") {
+			if trimmedLine == targetLine {
+				correctEntryExists = true
+			} else {
+				lines[i] = targetLine
+				configChanged = true
+			}
+		} else if strings.HasPrefix(trimmedLine, "#"+paramPrefix+"=") {
+			lines[i] = targetLine
+			configChanged = true
+		}
+	}
+
+	if !correctEntryExists {
+		lines = append(lines, targetLine)
+		configChanged = true
+	}
+
+	if configChanged {
+		newContent := strings.Join(lines, "\n")
+		
+		tempFile := filePath + ".tmp"
+		if err := os.WriteFile(tempFile, []byte(newContent), fileInfo.Mode()); err != nil {
+			return false, fmt.Errorf("failed to write temp config file %s: %w", tempFile, err)
+		}
+
+		if err := os.Rename(tempFile, filePath); err != nil {
+			os.Remove(tempFile)
+			return false, fmt.Errorf("failed to replace config file %s: %w", filePath, err)
+		}
+
+		logger.Infof("Updated %s in %s", paramPrefix, filePath)
+	}
+
+	return configChanged, nil
+}
+
+// UpdateModuleFile atomically enables or disables a kernel module in /etc/modules.
+// It handles commenting/uncommenting existing entries and preserves file permissions.
+func UpdateModuleFile(filePath, moduleName string, enable bool, logger logging.Logger) (bool, error) {
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		return false, fmt.Errorf("failed to stat modules file %s: %w", filePath, err)
+	}
+
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return false, fmt.Errorf("failed to read modules file %s: %w", filePath, err)
+	}
+
+	lines := strings.Split(string(content), "\n")
+	moduleFound := false
+	configChanged := false
+
+	for i, line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+		if trimmedLine == moduleName {
+			moduleFound = true
+			if !enable {
+				lines[i] = "#" + line
+				configChanged = true
+			}
+		} else if trimmedLine == "#"+moduleName {
+			if enable {
+				lines[i] = moduleName
+				configChanged = true
+				moduleFound = true
+			} else {
+				moduleFound = true
+			}
+		}
+	}
+
+	if enable && !moduleFound {
+		lines = append(lines, moduleName)
+		configChanged = true
+	}
+
+	if configChanged {
+		newContent := strings.Join(lines, "\n")
+		
+		tempFile := filePath + ".tmp"
+		if err := os.WriteFile(tempFile, []byte(newContent), fileInfo.Mode()); err != nil {
+			return false, fmt.Errorf("failed to write temp modules file %s: %w", tempFile, err)
+		}
+
+		if err := os.Rename(tempFile, filePath); err != nil {
+			os.Remove(tempFile)
+			return false, fmt.Errorf("failed to replace modules file %s: %w", filePath, err)
+		}
+
+		action := "Added"
+		if !enable {
+			action = "Disabled"
+		}
+		logger.Infof("%s %s in %s", action, moduleName, filePath)
+	}
+
+	return configChanged, nil
+}
+
+// GetBootConfigPath returns the correct path for boot config file.
+// Handles both /boot/config.txt (older) and /boot/firmware/config.txt (newer).
+func GetBootConfigPath() string {
+	if _, err := os.Stat("/boot/firmware/config.txt"); err == nil {
+		return "/boot/firmware/config.txt"
+	}
+	return "/boot/config.txt"
+}

--- a/utils/system_helpers.go
+++ b/utils/system_helpers.go
@@ -1,0 +1,23 @@
+package rpiutils
+
+import (
+	"os/exec"
+
+	"go.viam.com/rdk/logging"
+)
+
+// PerformReboot attempts to reboot the system using multiple fallback methods.
+// It tries systemctl first, then sudo shutdown, and finally logs a warning if both fail.
+func PerformReboot(logger logging.Logger) {
+
+	if err := exec.Command("systemctl", "reboot").Run(); err != nil {
+		logger.Debugf("systemctl reboot failed: %v", err)
+		
+		// TODO: Do you need sudo here?
+		if err := exec.Command("sudo", "shutdown", "-r", "now").Run(); err != nil {
+			logger.Debugf("sudo shutdown failed: %v", err)
+			
+			logger.Warnf("Automatic reboot failed. Please manually reboot the system for I2C changes to take effect: sudo reboot")
+		}
+	}
+}


### PR DESCRIPTION
Adds enable_i2c configuration option to automatically enable/disable I2C on Raspberry Pi boards (Pi 0-5).

When set to true, enables dtparam=i2c_arm=on in boot config, adds i2c-dev to /etc/modules, and automatically reboots. Setting to false disables I2C with reboot.

Example:
```json
{
    "enable_i2c": true
}
```

**Known shortcomings:**
- No tests!  If tests are required, some pointers on what should be tested would be helpful given that this is primarily file system operation.
- File system and reboot functionality pulled into dedicated files, but still somewhat duplicative code between `rpi/board.go` and `pi5/board.go`.  Should this be centralized?  If so where?