### PR TITLE
fix(board): use enable_i2c in place of turn_i2c_on

### DIFF
--- a/pi5/board.go
+++ b/pi5/board.go
@@ -640,9 +640,9 @@ func (b *pinctrlpi5) updateBTbaudrate(configPath string, rate int) (bool, bool) 
 }
 
 func (b *pinctrlpi5) configureI2C(cfg *rpiutils.Config) {
-	b.logger.Debugf("cfg.BoardSettings.TurnI2COn=%v", cfg.BoardSettings.TurnI2COn)
+	b.logger.Debugf("cfg.BoardSettings.I2Cenable=%v", cfg.BoardSettings.I2Cenable)
 	// Only enable I2C if turn_i2c_on is true, otherwise do nothing
-	if !cfg.BoardSettings.TurnI2COn {
+	if !cfg.BoardSettings.I2Cenable {
 		return
 	}
 

--- a/rpi/board.go
+++ b/rpi/board.go
@@ -51,7 +51,7 @@ var (
 )
 
 var (
-	boardInstance   *piPigpio    // global instance of raspberry pi borad for interrupt callbacks
+	boardInstance   *piPigpio    // global instance of raspberry pi board for interrupt callbacks
 	boardInstanceMu sync.RWMutex // mutex to protect boardInstance
 )
 
@@ -484,9 +484,9 @@ func (pi *piPigpio) updateBTbaudrate(configPath string, rate int) (bool, bool) {
 }
 
 func (pi *piPigpio) configureI2C(cfg *rpiutils.Config) error {
-	pi.logger.Debugf("cfg.BoardSettings.TurnI2COn=%v", cfg.BoardSettings.TurnI2COn)
+	pi.logger.Debugf("cfg.BoardSettings.I2Cenable=%v", cfg.BoardSettings.I2Cenable)
 	// Only enable I2C if turn_i2c_on is true, otherwise do nothing
-	if !cfg.BoardSettings.TurnI2COn {
+	if !cfg.BoardSettings.I2Cenable {
 		return nil
 	}
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -13,7 +13,7 @@ var RaspiFamily = resource.NewModelFamily("viam", "raspberry-pi")
 
 // BoardSettings contains board-level configuration options.
 type BoardSettings struct {
-	TurnI2COn    bool  `json:"turn_i2c_on,omitempty"`
+	I2Cenable    bool  `json:"enable_i2c,omitempty"`
 	BTenableuart *bool `json:"bluetooth_enable_uart,omitempty"`
 	BTdtoverlay  *bool `json:"bluetooth_dtoverlay_miniuart,omitempty"`
 	BTkbaudrate  *int  `json:"bluetooth_baud_rate,omitempty"`
@@ -23,7 +23,7 @@ type BoardSettings struct {
 type Config struct {
 	AnalogReaders []mcp3008helper.MCP3008AnalogConfig `json:"analogs,omitempty"`
 	Pins          []PinConfig                         `json:"pins,omitempty"`
-	BoardSettings BoardSettings                       `json:"board_settings,omitempty"`
+	BoardSettings BoardSettings                       `json:"board_settings"`
 }
 
 // Validate ensures all parts of the config are valid.

--- a/utils/file_helpers_test.go
+++ b/utils/file_helpers_test.go
@@ -15,49 +15,49 @@ func TestI2CConfiguration(t *testing.T) {
 
 	testCases := []struct {
 		name          string
-		turnI2COn     bool
+		i2cEnable     bool
 		expectChange  bool
 		initialConfig string
 		initialModule string
 	}{
 		{
 			name:          "turn_on_from_scratch",
-			turnI2COn:     true,
+			i2cEnable:     true,
 			expectChange:  true,
 			initialConfig: "",
 			initialModule: "",
 		},
 		{
 			name:          "turn_on_already_enabled",
-			turnI2COn:     true,
+			i2cEnable:     true,
 			expectChange:  false,
 			initialConfig: "dtparam=i2c_arm=on\n",
 			initialModule: "i2c-dev\n",
 		},
 		{
 			name:          "turn_on_from_commented",
-			turnI2COn:     true,
+			i2cEnable:     true,
 			expectChange:  true,
 			initialConfig: "#dtparam=i2c_arm=on\n",
 			initialModule: "#i2c-dev\n",
 		},
 		{
 			name:          "false_does_nothing_empty",
-			turnI2COn:     false,
+			i2cEnable:     false,
 			expectChange:  false,
 			initialConfig: "",
 			initialModule: "",
 		},
 		{
 			name:          "false_does_nothing_enabled",
-			turnI2COn:     false,
+			i2cEnable:     false,
 			expectChange:  false,
 			initialConfig: "dtparam=i2c_arm=on\n",
 			initialModule: "i2c-dev\n",
 		},
 		{
 			name:          "false_does_nothing_disabled",
-			turnI2COn:     false,
+			i2cEnable:     false,
 			expectChange:  false,
 			initialConfig: "dtparam=i2c_arm=off\n",
 			initialModule: "#i2c-dev\n",
@@ -81,7 +81,7 @@ func TestI2CConfiguration(t *testing.T) {
 			var configChanged, moduleChanged bool
 			var err error
 
-			if tc.turnI2COn {
+			if tc.i2cEnable {
 				configChanged, err = UpdateConfigFile(configPath, "dtparam=i2c_arm", "on", logger)
 				test.That(t, err, test.ShouldBeNil)
 
@@ -126,25 +126,25 @@ func TestI2CConfigIntegration(t *testing.T) {
 		expectCalls bool
 	}{
 		{
-			name: "turn_i2c_on_true",
+			name: "i2c_enable_true",
 			config: Config{
 				BoardSettings: BoardSettings{
-					TurnI2COn: true,
+					I2Cenable: true,
 				},
 			},
 			expectCalls: true,
 		},
 		{
-			name: "turn_i2c_on_false",
+			name: "i2c_enable_false",
 			config: Config{
 				BoardSettings: BoardSettings{
-					TurnI2COn: false,
+					I2Cenable: false,
 				},
 			},
 			expectCalls: false,
 		},
 		{
-			name: "turn_i2c_on_omitted",
+			name: "i2c_enable_omitted",
 			config: Config{
 				BoardSettings: BoardSettings{},
 			},
@@ -155,7 +155,7 @@ func TestI2CConfigIntegration(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Test that the logic correctly interprets the config
-			shouldEnable := tc.config.BoardSettings.TurnI2COn
+			shouldEnable := tc.config.BoardSettings.I2Cenable
 			test.That(t, shouldEnable, test.ShouldEqual, tc.expectCalls)
 		})
 	}


### PR DESCRIPTION
The README documents a field called `enable_i2c` under the `board_settings` config for the Raspberry Pi board modules. The code was actually using `turn_i2c_on`. Rather than updating the README, I chose to update the code to use the better name. 