### PR TITLE
[RSDK-12176] warn when pwm config is missing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/edaniels/golinters v0.0.5-0.20220906153528-641155550742
 	github.com/pkg/errors v0.9.1
 	github.com/rhysd/actionlint v1.7.8
-	github.com/viam-modules/pinctrl v0.0.0-20241213172831-bdf11253b4c3
+	github.com/viam-modules/pinctrl v0.0.0-20251230164603-b51a5031d7da
 	go.uber.org/multierr v1.11.0
 	go.viam.com/api v0.1.487
 	go.viam.com/rdk v0.102.1

--- a/go.sum
+++ b/go.sum
@@ -1200,6 +1200,8 @@ github.com/valyala/quicktemplate v1.6.3/go.mod h1:fwPzK2fHuYEODzJ9pkw0ipCPNHZ2tD
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/viam-modules/pinctrl v0.0.0-20241213172831-bdf11253b4c3 h1:TJwUzh2Z91fY7ERTbaAZcgl8gBOQZRU0OAx83XTb/l4=
 github.com/viam-modules/pinctrl v0.0.0-20241213172831-bdf11253b4c3/go.mod h1:klkE1Ll5blcoLTi8abPsujXNyLOY0cte5tHYOjTo5u8=
+github.com/viam-modules/pinctrl v0.0.0-20251230164603-b51a5031d7da h1:iC2TcpEluuppGM1h/K/1N99qQfwvSmS9Vx5Uofxu1aA=
+github.com/viam-modules/pinctrl v0.0.0-20251230164603-b51a5031d7da/go.mod h1:klkE1Ll5blcoLTi8abPsujXNyLOY0cte5tHYOjTo5u8=
 github.com/viamrobotics/ice/v2 v2.3.40 h1:H9r4ztsKkxWSn42R4fLvYlaPtpBys1Yj7/MERBtZY0k=
 github.com/viamrobotics/ice/v2 v2.3.40/go.mod h1:MFqB81U1pliDKaXJx2hGHvYKg1PepyEYwEY10828Ve0=
 github.com/viamrobotics/webrtc/v3 v3.99.16 h1:N3OQoWnV9Zg68mTDOq8ymsx2AMpbEjuo1gHWaVd7wB0=

--- a/pi5/board.go
+++ b/pi5/board.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	rpiutils "raspberry-pi/utils"
+
 	"github.com/pkg/errors"
 	"github.com/viam-modules/pinctrl/pinctrl"
 	"go.uber.org/multierr"
@@ -22,7 +24,6 @@ import (
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/utils"
-	rpiutils "raspberry-pi/utils"
 )
 
 // Model is the model for a Raspberry Pi 5.
@@ -727,5 +728,6 @@ func checkHardwarePWMOverlayIsConfigured() error {
 	}
 
 	// If we get here, the overlay is either missing or commented out
-	return fmt.Errorf("Hardware PWM overlay is not configured in %s. Some hardware PWM functions may not work. To enable hardware PWM, add 'dtoverlay=pwm-2chan' to your %s file and reboot.", configPath, configPath)
+	return fmt.Errorf("Hardware PWM overlay is not configured in %s. Some hardware PWM functions may not work."+
+		"To enable hardware PWM, add 'dtoverlay=pwm-2chan' to your %s file and reboot.", configPath, configPath)
 }

--- a/pi5/board.go
+++ b/pi5/board.go
@@ -12,8 +12,6 @@ import (
 	"sync"
 	"time"
 
-	rpiutils "raspberry-pi/utils"
-
 	"github.com/pkg/errors"
 	"github.com/viam-modules/pinctrl/pinctrl"
 	"go.uber.org/multierr"
@@ -24,6 +22,7 @@ import (
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/utils"
+	rpiutils "raspberry-pi/utils"
 )
 
 // Model is the model for a Raspberry Pi 5.
@@ -710,7 +709,7 @@ func (b *pinctrlpi5) Close(ctx context.Context) error {
 }
 
 // checkHardwarePWMOverlayIsConfigured checks if the hardware PWM overlay is enabled in config.txt.
-// If not present or commented out returns an error
+// If not present or commented out returns an error.
 func checkHardwarePWMOverlayIsConfigured() error {
 	configPath := "/boot/firmware/config.txt"
 	content, err := os.ReadFile(configPath)
@@ -728,6 +727,6 @@ func checkHardwarePWMOverlayIsConfigured() error {
 	}
 
 	// If we get here, the overlay is either missing or commented out
-	return fmt.Errorf("Hardware PWM overlay is not configured in %s. Some hardware PWM functions may not work."+
-		"To enable hardware PWM, add 'dtoverlay=pwm-2chan' to your %s file and reboot.", configPath, configPath)
+	return fmt.Errorf("hardware PWM overlay is not configured in %s. Some hardware PWM functions may not work."+
+		"To enable hardware PWM, add 'dtoverlay=pwm-2chan' to your %s file and reboot", configPath, configPath)
 }

--- a/pi5/board.go
+++ b/pi5/board.go
@@ -97,6 +97,12 @@ func newBoard(
 	if !isPi5 && !testingMode {
 		return nil, rpiutils.WrongModelErr(conf.Name)
 	}
+
+	// Check for hardware PWM overlay in config.txt
+	if err = checkHardwarePWMOverlayIsConfigured(); err != nil {
+		logger.Warnf("%v", err)
+	}
+
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 
 	b := &pinctrlpi5{
@@ -700,4 +706,26 @@ func (b *pinctrlpi5) Close(ctx context.Context) error {
 		err = multierr.Combine(err, interrupt.Close())
 	}
 	return err
+}
+
+// checkHardwarePWMOverlayIsConfigured checks if the hardware PWM overlay is enabled in config.txt.
+// If not present or commented out returns an error
+func checkHardwarePWMOverlayIsConfigured() error {
+	configPath := "/boot/firmware/config.txt"
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("couldn't read %s", configPath)
+	}
+
+	lines := strings.Split(string(content), "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "dtoverlay=pwm-2chan") {
+			// dtoverlay=pwm-2chan is uncommented
+			return nil
+		}
+	}
+
+	// If we get here, the overlay is either missing or commented out
+	return fmt.Errorf("Hardware PWM overlay is not configured in %s. Some hardware PWM functions may not work. To enable hardware PWM, add 'dtoverlay=pwm-2chan' to your %s file and reboot.", configPath, configPath)
 }


### PR DESCRIPTION
Give user context if hardware pwm pins cannot be used
see https://github.com/viam-modules/pinctrl/pull/27

